### PR TITLE
*do not merge* ARM specific backtrace.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ libubacktrace_SONAME    ?= $(libubacktrace_SO).$(ABI_VERSION)
 libubacktrace_FULL_NAME ?= $(libubacktrace_SO).$(VERSION)
 INCLUDE                 ?= /usr/include
 PREFIX                  ?=
-LIBADD                  ?= -lc -ldl
+LIBADD                  ?= -lc -ldl -lgcc_eh
 
 CC         = $(CROSS_COMPILE)gcc
 STRIP      = $(CROSS_COMPILE)strip -x -R .note -R .comment

--- a/backtrace.c
+++ b/backtrace.c
@@ -1,29 +1,14 @@
 /*
  * Perform stack unwinding by using the _Unwind_Backtrace.
  *
- * User application that wants to use backtrace needs to be compiled
- * with -fasynchronous-unwind-tables option and -rdynamic to get full
- * symbols printed.
+ * User application that wants to use backtrace needs to be
+ * compiled with -fasynchronous-unwid-tables option and -rdynamic i
+ * to get full symbols printed.
  *
- * Copyright (C) 2009, 2010 STMicroelectronics Ltd.
+ * Author(s): Khem Raj <raj.khem@gmail.com>
+ * - ARM specific implementation of backtrace
  *
- * Author(s): Giuseppe Cavallaro <peppe.cavallaro@st.com>
- * - Initial implementation for glibc
- *
- * Author(s): Carmelo Amoroso <carmelo.amoroso@st.com>
- * - Reworked for uClibc
- *   - use dlsym/dlopen from libdl
- *   - rewrite initialisation to not use libc_once
- *   - make it available in static link too
- *
- * Licensed under the LGPL v2.1, see the file COPYING in this tarball.
- *
- *
- * Based on uClibc/libubacktrace/backtrace.c
- *
- * Copyright (C) 2016 Gentoo Foundation
- * Author(s): Anthony G. Basile
- * - reduce to just dynamic link
+ * Licensed under the LGPL v2.1, see the file COPYING.LIB in this tarball.
  *
  */
 
@@ -41,26 +26,43 @@ struct trace_arg
 };
 
 static _Unwind_Reason_Code (*unwind_backtrace) (_Unwind_Trace_Fn, void *);
-static _Unwind_Ptr (*unwind_getip) (struct _Unwind_Context *);
+static _Unwind_VRS_Result (*unwind_vrs_get) (_Unwind_Context *,
+					     _Unwind_VRS_RegClass,
+					     _uw,
+					     _Unwind_VRS_DataRepresentation,
+					     void *);
 
 static void backtrace_init (void)
 {
 	void *handle = dlopen (LIBGCC_S_SO, RTLD_LAZY);
-
 	if (handle == NULL
 		|| ((unwind_backtrace = dlsym (handle, "_Unwind_Backtrace")) == NULL)
-		|| ((unwind_getip = dlsym (handle, "_Unwind_GetIP")) == NULL)) {
+		|| ((unwind_vrs_get = dlsym (handle, "_Unwind_VRS_Get")) == NULL)) {
 		printf(LIBGCC_S_SO " must be installed for backtrace to work\n");
 		abort();
 	}
 }
+/* This function is identical to "_Unwind_GetGR", except that it uses
+   "unwind_vrs_get" instead of "_Unwind_VRS_Get".  */
+static inline _Unwind_Word
+unwind_getgr (_Unwind_Context *context, int regno)
+{
+  _uw val;
+  unwind_vrs_get (context, _UVRSC_CORE, regno, _UVRSD_UINT32, &val);
+  return val;
+}
+
+/* This macro is identical to the _Unwind_GetIP macro, except that it
+   uses "unwind_getgr" instead of "_Unwind_GetGR".  */
+#define unwind_getip(context) \
+ (unwind_getgr (context, 15) & ~(_Unwind_Word)1)
 
 static _Unwind_Reason_Code
 backtrace_helper (struct _Unwind_Context *ctx, void *a)
 {
 	struct trace_arg *arg = a;
 
-	assert (unwind_getip != NULL);
+	assert (unwind_vrs_get != NULL);
 
 	/* We are first called with address in the __backtrace function. Skip it. */
 	if (arg->cnt != -1)


### PR DESCRIPTION
This is related to issue #1. uclibc-ng has an ARM specific backtrace.c file. This is the result of porting it. I can now successfully run the backtrace tests on ARM.Merging this as it is would of course break all other archs. We could have a separate backtrace.c for ARM or combine the two files.